### PR TITLE
Feature #9: implement persistence in local storage

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -6,3 +6,4 @@
 - [Bicheka](https://github.com/Bicheka) **First Contribution**
 - [m1her](https://github.com/m1her) **Contributed**
 - [Jatin Tyagi](https://github.com/jatintyagi1) **contributed** 
+- [AndresCasasola](https://github.com/AndresCasasola) **Contributed**

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-router-dom": "^6.22.3",
         "react-scripts": "5.0.1",
         "recoil": "^0.7.7",
+        "recoil-persist": "^5.1.0",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -15485,6 +15486,15 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/recoil-persist": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-5.1.0.tgz",
+      "integrity": "sha512-sew4k3uBVJjRWKCSFuBw07Y1p1pBOb0UxLJPxn4G2bX/9xNj+r2xlqYy/BRfyofR/ANfqBU04MIvulppU4ZC0w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "recoil": "^0.7.2"
       }
     },
     "node_modules/recursive-readdir": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-router-dom": "^6.22.3",
     "react-scripts": "5.0.1",
     "recoil": "^0.7.7",
+    "recoil-persist": "^5.1.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/utils/state.js
+++ b/src/utils/state.js
@@ -1,6 +1,10 @@
 import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+
+const { persistAtom } = recoilPersist()
 
 export const itemsState = atom({
   key: 'itemsState',
   default: [],
+  effects_UNSTABLE: [persistAtom],
 });


### PR DESCRIPTION
## Implement Items States Persistence in Local Storage

### Overview

After reading recoil library docs, it seems to be a good solution for unified state management and the current implementation already implement it for the different component views (Notes, Boards and Tables). I mean, all the components uses the same items state, so I think it's working well.

But natively recoil library doesn't support persistence for local storage, so for implementing persistence can be used an extension package of it named [recoil-persist](https://www.npmjs.com/package/recoil-persist).

This PR implements persistence in local storage for the items state using `recoil-persist`.

### Changes made

1. Install `recoil-persist`
2. Configure itemsState in `state.js` to be persistent.

### Testing

- Verified that when creating some Notes, all of them appears in the different views (Notes, Boards and Tables). And when updating states like 'held' or 'checked', also get update in all the views.

- Verified that created Notes persist after F5 reloads and when closing the tab and opening the application again.

### Related Issues

- #9 