### PR TITLE
Used tailwind grid to correct issue #16

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -3,6 +3,8 @@
 - [Narain Karthik](https://github.com/narainkarthikv) **Owner of Sticky-Memo**
 
 ## Open Source Contributors
+
 - [Bicheka](https://github.com/Bicheka) **First Contribution**
 - [m1her](https://github.com/m1her) **Contributed**
-- [Jatin Tyagi](https://github.com/jatintyagi1) **contributed** 
+- [Jatin Tyagi](https://github.com/jatintyagi1) **contributed**
+- [Vimal Vinod](https://github.com/dalekvim) **Contributed to this Project**

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
       },
       "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
-        "nodemon": "^3.1.4"
+        "nodemon": "^3.1.4",
+        "tailwindcss": "^3.4.9"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -17023,9 +17024,9 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "node_modules/tailwindcss": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
-      "integrity": "sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==",
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.9.tgz",
+      "integrity": "sha512-1SEOvRr6sSdV5IDf9iC+NU4dhwdqzF4zKKq3sAbasUWHEM6lsMhX+eNN5gkPx1BvLFEnZQEUFbXnGj8Qlp83Pg==",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -17035,7 +17036,7 @@
         "fast-glob": "^3.3.0",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
-        "jiti": "^1.19.1",
+        "jiti": "^1.21.0",
         "lilconfig": "^2.1.0",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
-    "nodemon": "^3.1.4"
+    "nodemon": "^3.1.4",
+    "tailwindcss": "^3.4.9"
   }
 }

--- a/src/components/CreateArea.component.jsx
+++ b/src/components/CreateArea.component.jsx
@@ -52,6 +52,7 @@ function CreateArea(props) {
           placeholder="Title"
           className="CreateArea-input"
           autoComplete="true"
+          style={{ maxWidth: "100%", backgroundColor: "transparent" }}
         />
 
         <textarea

--- a/src/components/CreateArea.component.jsx
+++ b/src/components/CreateArea.component.jsx
@@ -1,11 +1,10 @@
 import React, { useState } from "react";
-import '../styles/NoteList.component.css';
-
+import "../styles/NoteList.component.css";
 
 function CreateArea(props) {
   const [note, setNote] = useState({
     title: "",
-    content: ""
+    content: "",
   });
 
   const [isValid, setIsValid] = useState(false);
@@ -16,16 +15,16 @@ function CreateArea(props) {
 
   function submitNote(event) {
     if (!isValid) {
-        alert("Don't Waste Notes :)");
-        event.preventDefault();
-        return; 
+      alert("Don't Waste Notes :)");
+      event.preventDefault();
+      return;
     }
-    
+
     if (isValid) {
       props.onAdd(note);
       setNote({
         title: "",
-        content: ""
+        content: "",
       });
       setIsValid(false);
     }
@@ -37,11 +36,11 @@ function CreateArea(props) {
     setNote((prevNote) => {
       return {
         ...prevNote,
-        [name]: value
+        [name]: value,
       };
     });
   }
-  
+
   return (
     <div>
       <form className="CreateArea">
@@ -69,9 +68,7 @@ function CreateArea(props) {
         <button className="CreateArea-btn" onClick={submitNote}>
           Add
         </button>
-
       </form>
-
     </div>
   );
 }

--- a/src/components/CreateArea.component.jsx
+++ b/src/components/CreateArea.component.jsx
@@ -50,9 +50,8 @@ function CreateArea(props) {
           onChange={handleChange}
           onBlur={validateForm}
           placeholder="Title"
-          className="CreateArea-input"
+          className="CreateArea-input w-full"
           autoComplete="true"
-          style={{ maxWidth: "100%", backgroundColor: "transparent" }}
         />
 
         <textarea

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,17 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
+    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }

--- a/src/pages/NoteList.component.jsx
+++ b/src/pages/NoteList.component.jsx
@@ -30,7 +30,7 @@ const NoteList = () => {
   };
 
   return (
-    <div className="NoteList">
+    <div className="NoteList grid">
       <div className="create-and-filter-container">
         <CreateArea onAdd={(newItem) => addItem(setItems, newItem)} />
       </div>

--- a/src/pages/NoteList.component.jsx
+++ b/src/pages/NoteList.component.jsx
@@ -1,10 +1,10 @@
-import React, { useState } from 'react';
-import { useRecoilState } from 'recoil';
-import { itemsState } from '../utils/state';
-import CreateArea from '../components/CreateArea.component';
-import Note from '../components/Note.component';
-import '../styles/NoteList.component.css';
-import { addItem, deleteItem, checkItem, holdItem } from '../utils/helper';
+import React, { useState } from "react";
+import { useRecoilState } from "recoil";
+import CreateArea from "../components/CreateArea.component";
+import Note from "../components/Note.component";
+import "../styles/NoteList.component.css";
+import { addItem, checkItem, deleteItem, holdItem } from "../utils/helper";
+import { itemsState } from "../utils/state";
 
 const NoteList = () => {
   const [items, setItems] = useRecoilState(itemsState);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ["./src/**/*.{js,jsx,ts,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
This pull request prevents the notes from overflowing using Tailwind CSS's grid class.

(iPhone SE)
Before:
![image](https://github.com/user-attachments/assets/0859baa9-e146-43e8-bbfb-f6c61c5c8815)
After:
![image](https://github.com/user-attachments/assets/9eee1fd0-471d-426b-a014-0b201e435498)

(Nest Hub)
Before:
![image](https://github.com/user-attachments/assets/8fd0fbc3-b37e-49d3-8222-77227bd20ae4)
After:
![image](https://github.com/user-attachments/assets/fd0f8da5-9cdd-4eac-abd5-9894c5d0ce80)


Using Tailwind appears to have had an effect on the “Board” and “Table” pages.

(Board)
Before:
![image](https://github.com/user-attachments/assets/d009fc8e-1434-4e2d-9984-4e8e5a6ab869)
After:
![image](https://github.com/user-attachments/assets/76de955a-ac49-4926-8e9f-8e39d0e49660)

(Table)
Before:
![image](https://github.com/user-attachments/assets/a2d898bb-326e-470d-b8a6-9f4a79fc562a)
After:
![image](https://github.com/user-attachments/assets/d163a6d7-d2f4-4745-83ab-a952d263c58b)
