### PR TITLE
ui fixes on the table to avoid the clash with the footer 

### DIFF
--- a/src/components/Table/TableCard.jsx
+++ b/src/components/Table/TableCard.jsx
@@ -52,51 +52,55 @@ const TableCard = ({
       </TableCell>
       <TableCell align='center'>
         <Box sx={boxStyles}>
-          <Box sx={contentBoxStyles}>
-            {isEditing && editingIndex === index ? (
-              <TextField onChange={(e) => setEditedContent(e.target.value)} defaultValue={item.content} fullWidth multiline rows={4} />
-            ) : (
-              <span>{item.content}</span>
-            )}
-          </Box>
-          <IconButton aria-describedby={id} variant="contained" onClick={(e) => handleClickPopover(e, index)}>
-            <MoreVertIcon sx={buttonStyle} fontSize="small" />
-          </IconButton>
-          <Popover
-            id={id}
-            open={open}
-            anchorEl={anchorEl}
-            onClose={handleClosePopover}
-            anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
-          >
-            <Typography sx={popoverTypographyStyles}>
-              <IconButton
-                onClick={() => {
-                  if (isEditing) {
-                    handleSave(item, editingIndex, editedTitle, editedContent);
-                  } else {
-                    handleEdit();
-                  }
-                }}
-                variant='contained'
+          <Box sx={{ display: 'flex', width: '100%', justifyContent: 'space-between', alignItems: 'center' }}>
+            <Box sx={{ flex: { xs: '1 1 50%', sm: '1 1 66%' } }}>
+              {isEditing && editingIndex === index ? (
+                <TextField onChange={(e) => setEditedContent(e.target.value)} defaultValue={item.content} fullWidth multiline rows={4} />
+              ) : (
+                <span>{item.content}</span>
+              )}
+            </Box>
+            <Box sx={{ flex: { xs: '1 1 50%', sm: '1 1 33%' }, display: 'flex', justifyContent: 'flex-end' }}>
+              <IconButton aria-describedby={id} variant="contained" onClick={(e) => handleClickPopover(e, index)}>
+                <MoreVertIcon sx={buttonStyle} fontSize="small" />
+              </IconButton>
+              <Popover
+                id={id}
+                open={open}
+                anchorEl={anchorEl}
+                onClose={handleClosePopover}
+                anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
               >
-                {isEditing ? (
-                  <SaveIcon fontSize="small" sx={buttonStyle} />
-                ) : (
-                  <EditIcon fontSize="small" sx={buttonStyle} />
-                )}
-              </IconButton>
-              <IconButton onClick={() => holdItem(setItems, editingIndex, setSnackbar, 'Row')} variant="contained">
-                <BackHandIcon fontSize="small" sx={buttonStyle} />
-              </IconButton>
-              <IconButton onClick={() => checkItem(setItems, editingIndex, setSnackbar, 'Row')} variant="contained">
-                <CheckCircleIcon fontSize="small" sx={buttonStyle} />
-              </IconButton>
-              <IconButton onClick={() => deleteItem(setItems, editingIndex, setSnackbar, 'Row')} variant="contained">
-                <DeleteIcon fontSize="small" sx={buttonStyle} />
-              </IconButton>
-            </Typography>
-          </Popover>
+                <Typography sx={popoverTypographyStyles}>
+                  <IconButton
+                    onClick={() => {
+                      if (isEditing) {
+                        handleSave(item, editingIndex, editedTitle, editedContent);
+                      } else {
+                        handleEdit();
+                      }
+                    }}
+                    variant='contained'
+                  >
+                    {isEditing ? (
+                      <SaveIcon fontSize="small" sx={buttonStyle} />
+                    ) : (
+                      <EditIcon fontSize="small" sx={buttonStyle} />
+                    )}
+                  </IconButton>
+                  <IconButton onClick={() => holdItem(setItems, editingIndex, setSnackbar, 'Row')} variant="contained">
+                    <BackHandIcon fontSize="small" sx={buttonStyle} />
+                  </IconButton>
+                  <IconButton onClick={() => checkItem(setItems, editingIndex, setSnackbar, 'Row')} variant="contained">
+                    <CheckCircleIcon fontSize="small" sx={buttonStyle} />
+                  </IconButton>
+                  <IconButton onClick={() => deleteItem(setItems, editingIndex, setSnackbar, 'Row')} variant="contained">
+                    <DeleteIcon fontSize="small" sx={buttonStyle} />
+                  </IconButton>
+                </Typography>
+              </Popover>
+            </Box>
+          </Box>
         </Box>
       </TableCell>
     </TableRow>

--- a/src/components/common/styles.js
+++ b/src/components/common/styles.js
@@ -10,6 +10,7 @@ export const footerStyles = {
     left: 0,
     fontSize: '0.9em',
     backgroundColor: theme.palette.primary.main,
+    zIndex: 1,
   },
   inlineText: {
     display: 'inline',


### PR DESCRIPTION
The table was on top of  the footer and needed to be fixed imo since it sticks out as sore thumb.
![table](https://github.com/user-attachments/assets/ca37191f-f7f9-4704-af6f-68d59cb71d10)

also minor changes on the table row to make the contents part bit wide and allow the display to feel better.